### PR TITLE
Use PHPUnit attributes instead of annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.75",
-        "phpunit/phpunit": "^11.5",
+        "phpunit/phpunit": "^11.5||^12.1",
         "symfony/framework-bundle": "^6.4||^7.3",
         "symfony/http-kernel": "^6.4||^7.3",
         "symfony/phpunit-bridge": "^7.3",

--- a/tests/FeatureCheckerTest.php
+++ b/tests/FeatureCheckerTest.php
@@ -4,6 +4,7 @@ namespace Ajgarlag\FeatureFlagBundle\Tests;
 
 use Ajgarlag\FeatureFlagBundle\FeatureChecker;
 use Ajgarlag\FeatureFlagBundle\Provider\InMemoryProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FeatureCheckerTest extends TestCase
@@ -36,9 +37,7 @@ class FeatureCheckerTest extends TestCase
         $this->assertFalse($this->featureChecker->getValue('unknown_feature'));
     }
 
-    /**
-     * @dataProvider provideIsEnabled
-     */
+    #[DataProvider('provideIsEnabled')]
     public function testIsEnabled(string $featureName, bool $expectedResult)
     {
         $this->assertSame($expectedResult, $this->featureChecker->isEnabled($featureName));


### PR DESCRIPTION
Allow running tests with phpunit/phpunit:^12.1