### PR TITLE
Drop support for symfony/*:<7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        symfony_version: ['6.4.*', '7.2.*', '7.3.*']
+        symfony_version: ['6.4.*', '7.3.*']
 
     name: PHP ${{ matrix.php }} Symfony ${{ matrix.symfony_version }}
 

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.75",
         "phpunit/phpunit": "^11.5",
-        "symfony/framework-bundle": "^6.4||^7.2",
-        "symfony/http-kernel": "^6.4||^7.2",
+        "symfony/framework-bundle": "^6.4||^7.3",
+        "symfony/http-kernel": "^6.4||^7.3",
         "symfony/phpunit-bridge": "^7.3",
-        "symfony/twig-bundle": "^6.4||^7.2",
-        "symfony/var-dumper": "^6.4||^7.2",
-        "symfony/yaml": "^6.4||^7.2",
+        "symfony/twig-bundle": "^6.4||^7.3",
+        "symfony/var-dumper": "^6.4||^7.3",
+        "symfony/yaml": "^6.4||^7.3",
         "twig/twig": "^2.12||^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Symfony 7.2 is unmaintained: https://symfony.com/releases/7.2 