### PR TITLE
Remove deprecated `set-output` command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  pull_request: ~
+  push: ~
+  workflow_dispatch: ~
 
 jobs:
   tests:


### PR DESCRIPTION
GitHub Action workflow `ci` is triggering the following deprecation warning:

> __PHP 8.2 Symfony 6.4.*__
>The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
