### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         php: ['8.2', '8.3', '8.4']
         symfony_version: ['6.4.*', '7.3.*']
+        include:
+          - php: '8.1'
+            symfony_version: '6.4.*'
 
     name: PHP ${{ matrix.php }} Symfony ${{ matrix.symfony_version }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.1",
         "psr/container": "^1.1|^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.80",
-        "phpunit/phpunit": "^11.5||^12.1",
+        "phpunit/phpunit": "^10.5||^11.5||^12.1",
         "symfony/framework-bundle": "^6.4||^7.3",
         "symfony/http-kernel": "^6.4||^7.3",
         "symfony/phpunit-bridge": "^7.3",


### PR DESCRIPTION
Although PHP 8.1 is no longer maintained, the bundle is compatible with Symfony 6.4 which requires `"php": ">=8.1"`.

We can add support for PHP 8.1 at no cost.